### PR TITLE
Create ESM and CJS package entry points exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,39 +4,6 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@types/estree": {
-            "version": "0.0.47",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-            "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "14.14.37",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
-            "dev": true
-        },
-        "@types/resolve": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-            "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "builtin-modules": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-            "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
-            "dev": true
-        },
-        "estree-walker": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-            "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-            "dev": true
-        },
         "fsevents": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -44,64 +11,10 @@
             "dev": true,
             "optional": true
         },
-        "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
-        },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "is-core-module": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.3"
-            }
-        },
-        "is-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-            "dev": true
-        },
-        "is-reference": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-            "dev": true,
-            "requires": {
-                "@types/estree": "*"
-            }
-        },
-        "magic-string": {
-            "version": "0.25.7",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-            "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-            "dev": true,
-            "requires": {
-                "sourcemap-codec": "^1.4.4"
-            }
-        },
-        "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-            "dev": true
         },
         "readable-stream": {
             "version": "3.4.0",
@@ -113,70 +26,19 @@
                 "util-deprecate": "^1.0.1"
             }
         },
-        "resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-            "dev": true,
-            "requires": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
-            }
-        },
         "rollup": {
-            "version": "2.44.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.44.0.tgz",
-            "integrity": "sha512-rGSF4pLwvuaH/x4nAS+zP6UNn5YUDWf/TeEU5IoXSZKBbKRNTCI3qMnYXKZgrC0D2KzS2baiOZt1OlqhMu5rnQ==",
+            "version": "2.52.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.2.tgz",
+            "integrity": "sha512-4RlFC3k2BIHlUsJ9mGd8OO+9Lm2eDF5P7+6DNQOp5sx+7N/1tFM01kELfbxlMX3MxT6owvLB1ln4S3QvvQlbUA==",
             "dev": true,
             "requires": {
-                "fsevents": "~2.3.1"
-            }
-        },
-        "rollup-plugin-commonjs": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
-            "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
-            "dev": true,
-            "requires": {
-                "estree-walker": "^0.6.1",
-                "is-reference": "^1.1.2",
-                "magic-string": "^0.25.2",
-                "resolve": "^1.11.0",
-                "rollup-pluginutils": "^2.8.1"
-            }
-        },
-        "rollup-plugin-node-resolve": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
-            "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
-            "dev": true,
-            "requires": {
-                "@types/resolve": "0.0.8",
-                "builtin-modules": "^3.1.0",
-                "is-module": "^1.0.0",
-                "resolve": "^1.11.1",
-                "rollup-pluginutils": "^2.8.1"
-            }
-        },
-        "rollup-pluginutils": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-            "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-            "dev": true,
-            "requires": {
-                "estree-walker": "^0.6.1"
+                "fsevents": "~2.3.2"
             }
         },
         "safe-buffer": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
             "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        },
-        "sourcemap-codec": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "dev": true
         },
         "string_decoder": {
             "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,17 @@
     "name": "txml",
     "version": "4.0.1",
     "description": "fastest XML DOM Parser for node/browser/worker",
-    "main": "dixt/txml.js",
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
     "scripts": {
-        "build": "rollup -c && npm run buildTypes || npm run buildMinTypes",
-        "buildTypes": "./node_modules/.bin/tsc --allowjs -d dist/txml.js",
-        "buildMinTypes": "./node_modules/.bin/tsc --allowjs -d dist/min.txml.js",
+        "build": "rollup -c && npm run buildTypes",
+        "buildTypes": "tsc --allowjs --emitDeclarationOnly -d dist/index.js",
         "createTypes": "tsc --allowjs -d tXml.js",
         "test": "node test.js --trace-warnings"
     },
+    "files": [
+        "dist"
+    ],
     "repository": {
         "type": "git",
         "url": "git+https://github.com/TobiasNickel/tXml.git"
@@ -26,6 +29,20 @@
         "fast",
         "simple"
     ],
+    "exports": {
+        ".": {
+            "require": "./dist/index.js",
+            "import": "./dist/index.mjs"
+        },
+        "./txml": {
+            "require": "./dist/txml.js",
+            "import": "./dist/txml.mjs"
+        },
+        "./transformStream": {
+            "require": "./dist/transformStream.js",
+            "import": "./dist/transformStream.mjs"
+        }
+    },
     "author": "Tobias Nickel",
     "license": "MIT",
     "bugs": {
@@ -37,9 +54,7 @@
         "through2": "^3.0.1"
     },
     "devDependencies": {
-        "rollup": "^2.44.0",
-        "rollup-plugin-commonjs": "^10.1.0",
-        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup": "^2.52.2",
         "typescript": "^4.2.3"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 const config = {
   dir: 'dist',
+  // Small hack to lowercase tXml in bundle
   sanitizeFileName: (f) => f.includes('tXml') ? f.toLowerCase() : f,
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,35 +1,23 @@
+const baseConfig = {
+  dir: 'dist',
+  sanitizeFileName: (f) => f.includes('tXml') ? f.toLowerCase() : f,
+};
 
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
-
-export default [
-  {
-    input: './index.js',
-    
-    output: {
-      file: 'dist/txml.js',
-      format: 'cjs'
+export default {
+  input: ['index.js', 'tXml.js', 'transformStream.js'],
+  output: [
+    {
+      ...baseConfig,
+      format: 'cjs',
+      entryFileNames: '[name].js',
     },
-    plugins: [
-      resolve(),
-      commonjs()
-    ],  
-    external: [
-      'through2'
-    ]
-  },{
-    input: './tXml.js',
-    
-    output: {
-      file: 'dist/min.txml.js',
-      format: 'cjs'
+    {
+      ...baseConfig,
+      format: 'esm',
+      entryFileNames: '[name].mjs',
     },
-    plugins: [
-      resolve(),
-      commonjs()
-    ],  
-    external: [
-      'through2'
-    ]
-  },
-];
+  ],
+  external: [
+    'through2'
+  ]
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-const baseConfig = {
+const config = {
   dir: 'dist',
   sanitizeFileName: (f) => f.includes('tXml') ? f.toLowerCase() : f,
 };
@@ -7,12 +7,12 @@ export default {
   input: ['index.js', 'tXml.js', 'transformStream.js'],
   output: [
     {
-      ...baseConfig,
+      ...config,
       format: 'cjs',
       entryFileNames: '[name].js',
     },
     {
-      ...baseConfig,
+      ...config,
       format: 'esm',
       entryFileNames: '[name].mjs',
     },

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const tXml = require('./dist/txml');
+const tXml = require('.');
 const assert = require('assert');
 const fs = require('fs');
 

--- a/transformStream.js
+++ b/transformStream.js
@@ -1,5 +1,5 @@
 import {parse} from './tXml.js'
-const through2 = require('through2');
+import through2 from 'through2';
 
 export function transformStream(offset, parseOptions) {
     if(!parseOptions) parseOptions = {};


### PR DESCRIPTION
Seems related to #22 

Thanks for all your work on tXml! It is a really quality library.

I have been working on making a more browser-friendly (ESM-first) build for https://github.com/geotiffjs/geotiff.js/, which uses tXml, and ran into the issue of the package hoisting of the `through2` in the final bundle. geotiff only uses the `parse` export from tXml, so I looked into making separate entrypoints and found you already have done so (thanks!). 

This PR adds to your work by specifying node [package entry points](https://nodejs.org/api/packages.html#packages_package_entry_points). Package entry points are understood by both node and bundlers, allowing for conditional resolution based on `import` or `require` statements for ESM and commonjs modules respectively. This PR:

- Removes unnecessary `rollup` plugins. `@rollup/plugin-node-resolve` is for resolving paths to `node_modules`; all dependencies for `tXml` are external so this is not needed.`@rollup/plugin-commonjs` is needed to when _bundling_ a commonjs module, but again all dependencies are external and all of tXml is written in ESM.

- Adds both ESM and CJS entry points. [ESM](https://nodejs.org/api/esm.html#esm_modules_ecmascript_modules) is now supported in all major browsers and node>=v12. Since this package is already written in ESM, it would be preferable to distribute that way as well (since ESM is nicer for bundlers, and will be increasingly more common).

- Specifies `import` and `require` package entry points:

```javascript
// npm install txml

// Usage
import * as txml from 'txml';
const txml = require('txml');

import {parse} from 'txml/txml'; // PURE JS import, will play very nicely with bundlers
const {parse} = require('txml/txml');

import {tranformStream} from 'txml/transfromStream';
const {transformStream} = 'txml/transformStream';
```

Let me know what I can do to help land these changes if they are of interest! Thanks again for all your work on this project.

