### PR TITLE
feat: wildcard export

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
         "./transformStream": {
             "require": "./dist/transformStream.js",
             "import": "./dist/transformStream.mjs"
-        }
+        },
+        "./*": "./*"
     },
     "author": "Tobias Nickel",
     "license": "MIT",


### PR DESCRIPTION
Introduced in #23, a side effect is that the `"exports"` restricts how txml may be imported. While package exports are a standard, they are not respected by all bundlers (specifically webpack<4), so we are unable to use `txml/txml` import in our source code.

This PR adds a wild-card export which permits that modules may be imported using an explicit path. For example, this currently raises an error with `txml`:

```javascript
import { parse } from 'txml/dist/txml.mjs'; // : Package subpath './dist/txml.mjs' is not defined by "exports" 
```

It would be great to have a patch release with this feature because it has been causing some issues in geotiff.js! Thanks again for your work on this project. It is an excellent module!