### PR TITLE
Fix type declarations in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "module": "dist/index.mjs",
     "scripts": {
         "build": "rollup -c && npm run buildTypes",
-        "buildTypes": "tsc --allowjs --emitDeclarationOnly -d dist/index.js",
+        "buildTypes": "tsc --allowjs --emitDeclarationOnly -d index.js transformStream.js tXml.js --outDir ./dist",
         "createTypes": "tsc --allowjs -d tXml.js",
         "test": "node test.js --trace-warnings"
     },


### PR DESCRIPTION
This should fix #29 by running tsc against the source files instead of the build files in `dist/` to generate type declarations (the previous generated `dist/index.d.ts` tried to export types that weren't imported or declared). This PR should fix the type declarations for `import * as txml from 'txml';` usage.