### PR TITLE
fix: readme example variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ const dom = txml.parse(`
         <p>hello</p>
     </body>
 </html>`);
-const styleElement = data.filter(dom, node=>node.tagName.toLowerCase() === 'style')[0];
+const styleElement = txml.filter(dom, node=>node.tagName.toLowerCase() === 'style')[0];
 ```
 
 ### **txml.getElementById** (xml, id) 


### PR DESCRIPTION
Use `txml`  rather than variable that doesn't exist in scope.